### PR TITLE
Replace stdint.h by hardcoded typedefs

### DIFF
--- a/minicov/c/InstrProfilingPort.h
+++ b/minicov/c/InstrProfilingPort.h
@@ -155,7 +155,21 @@ static inline size_t getpagesize() {
 
 #else /* defined(__FreeBSD__) */
 
-#include <stdint.h>
+typedef __UINT8_TYPE__ uint8_t;
+typedef __UINT16_TYPE__ uint16_t;
+typedef __UINT32_TYPE__ uint32_t;
+typedef __UINT64_TYPE__ uint64_t;
+
+typedef __INT8_TYPE__ int8_t;
+typedef __INT16_TYPE__ int16_t;
+typedef __INT32_TYPE__ int32_t;
+typedef __INT64_TYPE__ int64_t;
+
+typedef __SIZE_TYPE__ size_t;
+typedef __INT64_TYPE__ ssize_t;
+
+typedef __SIZE_TYPE__ uintptr_t;
+typedef __INT64_TYPE__ intptr_t;
 
 #endif /* defined(__FreeBSD__) && defined(__i386__) */
 


### PR DESCRIPTION
These should work for x86_64, untested in other environments.